### PR TITLE
Textfile normalization from the repo is set to Unix style (no change her...

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+*.sln    merge=union
+*.csproj merge=union
+*.vbproj merge=union
+*.fsproj merge=union
+*.dbproj merge=union
+
+# Standard to msysgit
+*.doc	 diff=astextplain
+*.DOC	 diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF	 diff=astextplain
+*.rtf	 diff=astextplain
+*.RTF	 diff=astextplain


### PR DESCRIPTION
...e - but it is now declared.

I believe this is the stadard way to handle line ending for .net projects. It avoids confusion about how line endings should be handled on different platforms.

Based on: 
http://stackoverflow.com/a/10855862/587279
https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html#_end_of_line_conversion
https://help.github.com/articles/dealing-with-line-endings#per-repository-settings
